### PR TITLE
Show Telemetry Data for limited time on device

### DIFF
--- a/Device/AZ3166Leds.cpp
+++ b/Device/AZ3166Leds.cpp
@@ -17,43 +17,20 @@ static char displayBuffer[AZ3166_DISPLAY_SIZE];
  * 
  * Show Humidity, Temperature and Pressure readings on the on-board display.
  **************************************************************************************************************/
-void ShowTelemetryData(uint64_t upTime, uint64_t sensorReads, uint64_t telemetrySend, float temperature, float humidity, float pressure, bool showHumidity, bool showPressure)
+void ShowTelemetryData(float temperature, float humidity, float pressure, bool bShowData, bool showHumidity, bool showPressure)
 {
-    bool display1 = (changeDisplayTrigger < (upTime % 300));
-    char szUpHours[ULONG_64_MAX_DIGITS+1];
     char szSensor[ULONG_64_MAX_DIGITS+1];
     char szTelem[ULONG_64_MAX_DIGITS+1];
 
-#ifdef LOGGING
-    char szUp[ULONG_64_MAX_DIGITS+1];
-    char szSR[ULONG_64_MAX_DIGITS+1];
-    char szTS[ULONG_64_MAX_DIGITS+1];
-    char szDT[ULONG_64_MAX_DIGITS+1];
+    DEBUGMSG_FUNC_IN("(%.1f, %.1f, %.1f, %s, %s, %s)", temperature, humidity, pressure, ShowBool(bShowData), ShowBool(showHumidity), ShowBool(showPressure));
 
-    Int64ToString(upTime, szUp, ULONG_64_MAX_DIGITS);
-    Int64ToString(sensorReads, szSR, ULONG_64_MAX_DIGITS);
-    Int64ToString(telemetrySend, szTS, ULONG_64_MAX_DIGITS);
-    Int64ToString(changeDisplayTrigger, szDT, ULONG_64_MAX_DIGITS);
-
-    DEBUGMSG_FUNC_IN("(%s, %s, %s, %.1f, %.1f, %.1f, %s, %s)", szUp, szSR, szTS, temperature, humidity, pressure, ShowBool(showHumidity), ShowBool(showPressure));
-
-    DEBUGMSG(ZONE_SENSORDATA, "upTime = %s, sensorReads = %s, telemetrySend = %s", szUp, szSR, szTS);
-    DEBUGMSG(ZONE_SENSORDATA, "display1 = %s, changeDisplayTrigger = %s", ShowBool(display1),  szDT);
-#endif
-
-    changeDisplayTrigger = (upTime % 300);
-    Int64ToString(upTime / 3600, szUpHours, sizeof(szUpHours) - 1);
-
-    if (display1) {
-        snprintf(displayBuffer, AZ3166_DISPLAY_SIZE, "UP:%s\r\nTemp:%s C\r\nHumidity:%s%%\r\nPressure:%s\r\n",
-            szUpHours, f2s(temperature, 1), showHumidity ? f2s(humidity,1) : "-", showPressure ? f2s(pressure,1) : "-");
+    if (bShowData) {
+        snprintf(displayBuffer, AZ3166_DISPLAY_SIZE, "Environment\r\nTemp:%s C\r\nHumidity:%s%%\r\nPressure:%s\r\n",
+            f2s(temperature, 1), showHumidity ? f2s(humidity,1) : "-", showPressure ? f2s(pressure,1) : "-");
+            Screen.print(displayBuffer);
     } else {
-        Int64ToString(sensorReads, szSensor, 15);
-        Int64ToString(telemetrySend, szTelem, 15);
-        snprintf(displayBuffer, AZ3166_DISPLAY_SIZE, "#S:%s\r\n#T:%s\r\nTemp:%s\r\nH:%s%%-P:%s\r\n",
-            szSensor, szTelem, f2s(temperature, 1), showHumidity ? f2s(humidity,1) : "-", showPressure ? f2s(pressure,1) : "-");
+        Screen.clean();
     }
-    Screen.print(displayBuffer);
     DEBUGMSG_FUNC_OUT("");
 }
 

--- a/Device/AZ3166Leds.h
+++ b/Device/AZ3166Leds.h
@@ -1,7 +1,7 @@
 #ifndef AZ3166LEDS_H
 #define AZ3166LEDS_H
 
-void ShowTelemetryData(uint64_t upTime, uint64_t sensorReads, uint64_t telemetrySend, float temperature, float humidity, float pressure, bool showHumidity, bool showPressure);
+void ShowTelemetryData(float temperature, float humidity, float pressure, bool bShowData, bool showHumidity, bool showPressure);
 void BlinkLED();
 void BlinkSendConfirmation();
 

--- a/Device/Config.h
+++ b/Device/Config.h
@@ -32,10 +32,11 @@
 #define MESSAGE_MAX_LEN                         256
 #define REPORTED_PROPERTIES_MAX_LEN             1024
 #define DEFAULT_TEMPERATURE_ALERT               40
+#define DEFAULT_DISPLAY_TIME                    60
 
 #define DEVICE_ID                               "AZ3166-Proto"
 #define DEVICE_LOCATION                         "On the road"
-#define DEVICE_FIRMWARE_VERSION                 "2.1.0"
+#define DEVICE_FIRMWARE_VERSION                 "2.1.1"
 
 // Telemetry
 #define JSON_TEMPERATURE                        "temperature"

--- a/Device/DebugZones.h
+++ b/Device/DebugZones.h
@@ -88,8 +88,8 @@ extern DBGPARAM dpCurSettings;
 #define ZONEMASK_WARNING      ZONEMASK(14)
 #define ZONEMASK_ERROR        ZONEMASK(15)
 
-//#define DEBUGZONES      ZONEMASK_INIT | ZONEMASK_MAINLOOP | ZONEMASK_ERROR | ZONEMASK_WARNING
-#define DEBUGZONES      0xFFFF
+#define DEBUGZONES      ZONEMASK_FUNCTION | ZONEMASK_MAINLOOP | ZONEMASK_ERROR | ZONEMASK_WARNING
+//#define DEBUGZONES      0xFFFF
 
 #define DEBUGMSG(cond, ...) do { if (cond) { if (Serial.availableForWrite() < 150) { delay (300); } Serial.printf(" [%-25s] %04d - %s: ", __FILE__, __LINE__, FUNC_NAME); Serial.printf(__VA_ARGS__); Serial.printf("\r\n"); } } while ((void)0, 0)
 #define DEBUGMSG_RAW(cond, ...) do { if (cond) { if (Serial.availableForWrite() < MAX_RAW_MSG_BUFFER_SIZE) { delay (300); } Serial.printf(__VA_ARGS__); } } while ((void)0, 0)

--- a/Device/IoTHubDeviceMethods.cpp
+++ b/Device/IoTHubDeviceMethods.cpp
@@ -117,6 +117,15 @@ bool HandleMeasureNow(unsigned char **response, int *responseLength)
     return true;
 }
 
+bool HandleDisplayOn(unsigned char **response, int *responseLength)
+{
+    const char *ok = "{\"result\":\"OK\"}";
+    DEBUGMSG_FUNC_IN("(%p, %p)", *response, responseLength);
+    BuildResponseString(ok, response, responseLength);
+    DEBUGMSG_FUNC_OUT(" = true");
+    return true;
+}
+
 bool HandleUnknownMethod(unsigned char **response, int *responseLength)
 {
     const char *ok = "{\"result\":\"NOK\"}";

--- a/Device/IoTHubDeviceMethods.h
+++ b/Device/IoTHubDeviceMethods.h
@@ -1,6 +1,6 @@
 /**************************************************************************************************
  * Module Name: IoTHubDeviceMethods.h
- * Version:     2.0.9
+ * Version:     2.1.1
  * Description: Definition of all C2D methods that are available for this application.
  * Copyright (c) IoTForDevices. All rights reserved.
  * Licensed under the MIT license. 
@@ -10,6 +10,7 @@
 
 bool HandleReset(unsigned char **response, int *responseLength);
 bool HandleMeasureNow(unsigned char **response, int *responseLength);
+bool HandleDisplayOn(unsigned char **response, int *responseLength);
 bool HandleFirmwareUpdate(const char *payload, int payloadLength, unsigned char **response, int *responseLength);
 bool HandleResetFWVersion(const char *payload, int payloadLength, unsigned char **response, int *responseLength);
 void HandleUnknownMethod(unsigned char **response, int *responseLength);

--- a/Device/IoTHubMessageHandling.h
+++ b/Device/IoTHubMessageHandling.h
@@ -47,6 +47,7 @@ typedef union {
 #define IDX_DEVICEMODEL                 17
 #define IDX_DEVICELOCATION              18
 #define IDX_DEBUGMASK                   19
+#define IDX_DISPLAYTIME                 20
 
 #define IDX_TEMPERATURE_TELEMETRY       0
 #define IDX_HUMIDITY_TELEMETRY          1
@@ -54,8 +55,8 @@ typedef union {
 #define IDX_UPTIME_TELEMETRY            3
 
 //bool CreateTelemetryMessage(char *payload, bool forceCreate);
-bool CreateTelemetryMessage(char *payload, uint64_t upTime, uint64_t sensorReads, uint64_t telemetrySend, bool forceCreate);
-void CreateEventMsg(char* payLoad, IOTC_EVENT_TYPE eventType);
+bool CreateTelemetryMessage(char **ppszPayLoad, uint64_t upTime, bool forceCreate, bool bShowData);
+char *CreateEventMsg(IOTC_EVENT_TYPE eventType);
 bool SendDeviceInfo();
 bool ParseTwinMessage(DEVICE_TWIN_UPDATE_STATE updateState, const char *message, int msgLength);
 bool InitialDeviceTwinDesiredReceived();
@@ -65,6 +66,7 @@ int  SleepInterval();
 int  MotionInterval();
 int  WarmingUpTime();
 int  MotionSensitivity();
+int  DisplayOnInterval();
 bool MotionDetectionEnabled();
 bool UpdateReportedValues();
 char *CurrentFWVersion();


### PR DESCRIPTION
Telemetry data is displayed for a number of seconds on the device to protect the on-device display.
Controlling display of data is done through the IOTC application. There is also a setting available that specifies the number of seconds the display should be enabled.